### PR TITLE
Integración de Entity Framework y reorganización de proyectos

### DIFF
--- a/HotelApp.API/HotelApp.API.csproj
+++ b/HotelApp.API/HotelApp.API.csproj
@@ -14,4 +14,8 @@
     <Folder Include="Controllers\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\HotelApp.Infraestructure.Data\HotelApp.Infraestructure.Persistence.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/HotelApp.API/Program.cs
+++ b/HotelApp.API/Program.cs
@@ -1,3 +1,7 @@
+using HotelApp.Infraestructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using HotelApp.Infraestructure.Persistence.Context;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -6,6 +10,13 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+builder.Services.AddDbContext<HotelUltraGroupContext>(options =>
+{
+    options.UseSqlServer(builder.Configuration.GetConnectionString("SqlConecctionHotelUltraGroupDB"));
+});
+
+DependencyInjection.RegisterServices(builder.Services);
 
 var app = builder.Build();
 

--- a/HotelApp.API/appsettings.json
+++ b/HotelApp.API/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "SqlConecctionHotelUltraGroupDB": "Server=DESKTOP-9K0QVR1\\SQLEXPRESS;Database=HotelUltraGroupDB;User Id=LoginHotelUltraGroupDB;Password=LoginHotelUltraGroupDBPass;TrustServerCertificate=True;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/HotelApp.Application/HotelApp.Application.csproj
+++ b/HotelApp.Application/HotelApp.Application.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\HotelApp.Domain\HotelApp.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/HotelApp.Domain/Entities/DocumentType.cs
+++ b/HotelApp.Domain/Entities/DocumentType.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HotelApp.Domain.Entities
+{
+    public class DocumentType
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public ICollection<Guest> Guests { get; set; }
+    }
+}

--- a/HotelApp.Domain/Entities/Guest.cs
+++ b/HotelApp.Domain/Entities/Guest.cs
@@ -1,0 +1,15 @@
+﻿namespace HotelApp.Domain.Entities
+{
+    public class Guest
+    {
+        public int Id { get; set; }
+        public string FullName { get; set; }
+        public DateTime BirthDate { get; set; }
+        public string Gender { get; set; }
+        public int IdDocumentType { get; set; } 
+        public string DocumentNumber { get; set; }
+        public string Email { get; set; }
+        public string PhoneNumber { get; set; }
+        public DocumentType DocumentType { get; set; }
+    }
+}

--- a/HotelApp.Domain/Entities/Hotel.cs
+++ b/HotelApp.Domain/Entities/Hotel.cs
@@ -1,0 +1,14 @@
+﻿namespace HotelApp.Domain.Entities
+{
+    public class Hotel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Address { get; set; }
+        public string City { get; set; }
+        public bool IsActive { get; set; }
+        public ICollection<Room> Rooms { get; set; } = [];
+        public void Enable() => IsActive = true;
+        public void Disable() => IsActive = false;
+    }
+}

--- a/HotelApp.Domain/Entities/Reservation.cs
+++ b/HotelApp.Domain/Entities/Reservation.cs
@@ -1,0 +1,14 @@
+﻿namespace HotelApp.Domain.Entities
+{
+    public class Reservation
+    {
+        public int Id { get; set; }
+        public int HotelId { get; set; }
+        public DateTime CheckInDate { get; set; }
+        public DateTime CheckOutDate { get; set; }
+        public decimal TotalPrice { get; set; }
+        public string EmergencyContactName { get; set; }
+        public string EmergencyContactPhone { get; set; }
+        public Hotel Hotel { get; set; }
+    }
+}

--- a/HotelApp.Domain/Entities/ReservationDetailGuest.cs
+++ b/HotelApp.Domain/Entities/ReservationDetailGuest.cs
@@ -1,0 +1,11 @@
+﻿namespace HotelApp.Domain.Entities
+{
+    public class ReservationDetailGuest
+    {
+        public int Id { get; set; }
+        public int ReservationId { get; set; }
+        public int GuestId { get; set; }
+        public Reservation Reservation { get; set; }
+        public Guest Guest { get; set; }
+    }
+}

--- a/HotelApp.Domain/Entities/ReservationDetailRoom.cs
+++ b/HotelApp.Domain/Entities/ReservationDetailRoom.cs
@@ -1,0 +1,11 @@
+﻿namespace HotelApp.Domain.Entities
+{
+    public class ReservationDetailRoom
+    {
+        public int Id { get; set; }
+        public int ReservationId { get; set; }
+        public int RoomId { get; set; }
+        public Reservation Reservation { get; set; }
+        public Room Room { get; set; }
+    }
+}

--- a/HotelApp.Domain/Entities/Room.cs
+++ b/HotelApp.Domain/Entities/Room.cs
@@ -1,0 +1,15 @@
+﻿namespace HotelApp.Domain.Entities
+{
+    public class Room
+    {
+        public int Id { get; set; }
+        public int HotelId { get; set; }
+        public int IdRoomType { get; set; }
+        public string Location { get; set; }
+        public decimal BasePrice { get; set; }
+        public decimal Tax { get; set; }
+        public bool IsActive { get; set; }
+        public Hotel Hotel { get; set; }
+        public RoomType RoomType { get; set; }
+    }
+}

--- a/HotelApp.Domain/Entities/RoomType.cs
+++ b/HotelApp.Domain/Entities/RoomType.cs
@@ -1,0 +1,10 @@
+﻿namespace HotelApp.Domain.Entities
+{
+    public class RoomType
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public ICollection<Room> Rooms { get; set; }
+    }   
+}

--- a/HotelApp.Infraestructure.Data/Configurations/DocumentTypeConfiguration.cs
+++ b/HotelApp.Infraestructure.Data/Configurations/DocumentTypeConfiguration.cs
@@ -1,0 +1,18 @@
+﻿using HotelApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotelApp.Infraestructure.Persistence.Configurations
+{
+    public class DocumentTypeConfiguration : IEntityTypeConfiguration<DocumentType>
+    {
+        public void Configure(EntityTypeBuilder<DocumentType> builder)
+        {
+            builder.HasKey(dt => dt.Id);
+
+            builder.Property(dt => dt.Name)
+                .IsRequired()
+                .HasMaxLength(50);
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/Configurations/GuestConfiguration.cs
+++ b/HotelApp.Infraestructure.Data/Configurations/GuestConfiguration.cs
@@ -1,0 +1,29 @@
+﻿using HotelApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotelApp.Infraestructure.Persistence.Configurations
+{
+    public class GuestConfiguration : IEntityTypeConfiguration<Guest>
+    {
+        public void Configure(EntityTypeBuilder<Guest> builder)
+        {
+            builder.HasKey(g => g.Id);
+
+            builder.Property(g => g.FullName)
+                .IsRequired()
+                .HasMaxLength(200);
+
+            builder.Property(g => g.Email)
+                .HasMaxLength(100);
+
+            builder.Property(g => g.PhoneNumber)
+                .HasMaxLength(20);
+
+            builder.HasOne(g => g.DocumentType)
+                .WithMany(dt => dt.Guests)
+                .HasForeignKey(g => g.IdDocumentType)
+                .OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/Configurations/HotelConfiguration.cs
+++ b/HotelApp.Infraestructure.Data/Configurations/HotelConfiguration.cs
@@ -1,0 +1,31 @@
+﻿using HotelApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotelApp.Infraestructure.Persistence.Configurations
+{
+    public class HotelConfiguration : IEntityTypeConfiguration<Hotel>
+    {
+        public void Configure(EntityTypeBuilder<Hotel> builder)
+        {
+            builder.ToTable("Hotels");
+
+            builder.HasKey(h => h.Id);
+
+            builder.Property(h => h.Name)
+                   .IsRequired()
+                   .HasMaxLength(50);
+
+            builder.Property(h => h.Address)
+                   .IsRequired()
+                   .HasMaxLength(50);
+
+            builder.Property(h => h.City)
+                   .IsRequired()
+                   .HasMaxLength(50);
+
+            builder.Property(h => h.IsActive)
+                   .HasDefaultValue(true);
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/Configurations/ReservationConfiguration.cs
+++ b/HotelApp.Infraestructure.Data/Configurations/ReservationConfiguration.cs
@@ -1,0 +1,30 @@
+﻿using HotelApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotelApp.Infraestructure.Persistence.Configurations
+{
+    public class ReservationConfiguration : IEntityTypeConfiguration<Reservation>
+    {
+        public void Configure(EntityTypeBuilder<Reservation> builder)
+        {
+            builder.HasKey(r => r.Id);
+
+            builder.Property(r => r.TotalPrice)
+                .HasColumnType("decimal(18,2)");
+
+            builder.Property(r => r.EmergencyContactName)
+                .IsRequired()
+                .HasMaxLength(50);
+
+            builder.Property(r => r.EmergencyContactPhone)
+                .IsRequired()
+                .HasMaxLength(20);
+
+            builder.HasOne(r => r.Hotel)
+                .WithMany()
+                .HasForeignKey(r => r.HotelId)
+                .OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/Configurations/ReservationDetailGuestConfiguration.cs
+++ b/HotelApp.Infraestructure.Data/Configurations/ReservationDetailGuestConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using HotelApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotelApp.Infraestructure.Persistence.Configurations
+{
+    public class ReservationDetailGuestConfiguration : IEntityTypeConfiguration<ReservationDetailGuest>
+    {
+        public void Configure(EntityTypeBuilder<ReservationDetailGuest> builder)
+        {
+            builder.HasKey(rdg => rdg.Id);
+
+            builder.HasOne(rdg => rdg.Reservation)
+                .WithMany()
+                .HasForeignKey(rdg => rdg.ReservationId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasOne(rdg => rdg.Guest)
+                .WithMany()
+                .HasForeignKey(rdg => rdg.GuestId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/Configurations/ReservationDetailRoomConfiguration.cs
+++ b/HotelApp.Infraestructure.Data/Configurations/ReservationDetailRoomConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using HotelApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotelApp.Infraestructure.Persistence.Configurations
+{
+    public class ReservationDetailRoomConfiguration : IEntityTypeConfiguration<ReservationDetailRoom>
+    {
+        public void Configure(EntityTypeBuilder<ReservationDetailRoom> builder)
+        {
+            builder.HasKey(rdr => rdr.Id);
+
+            builder.HasOne(rdr => rdr.Reservation)
+                .WithMany()
+                .HasForeignKey(rdr => rdr.ReservationId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasOne(rdr => rdr.Room)
+                .WithMany()
+                .HasForeignKey(rdr => rdr.RoomId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/Configurations/RoomConfiguration.cs
+++ b/HotelApp.Infraestructure.Data/Configurations/RoomConfiguration.cs
@@ -1,0 +1,45 @@
+﻿using HotelApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotelApp.Infraestructure.Persistence.Configurations
+{
+    public class RoomConfiguration : IEntityTypeConfiguration<Room>
+    {
+        public void Configure(EntityTypeBuilder<Room> builder)
+        {
+            builder.ToTable("Rooms");
+
+            builder.HasKey(r => r.Id);
+
+            builder.Property(r => r.Location)
+                .IsRequired() 
+                .HasMaxLength(50);
+
+            builder.Property(r => r.BasePrice)
+                .HasColumnType("decimal(18,2)")
+                .IsRequired();
+
+            builder.Property(r => r.Tax)
+                .HasColumnType("decimal(18,2)")
+                .IsRequired();
+
+            builder.Property(r => r.IsActive)
+                .IsRequired()
+                .HasDefaultValue(true);
+
+            builder.HasOne(r => r.Hotel)
+                .WithMany(h => h.Rooms) 
+                .HasForeignKey(r => r.HotelId) 
+                .OnDelete(DeleteBehavior.Cascade); 
+
+
+            builder.HasOne(r => r.RoomType)
+                .WithMany() 
+                .HasForeignKey(r => r.IdRoomType) 
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasIndex(r => r.HotelId);
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/Configurations/RoomTypeConfiguration.cs
+++ b/HotelApp.Infraestructure.Data/Configurations/RoomTypeConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using HotelApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotelApp.Infraestructure.Persistence.Configurations
+{
+    public class RoomTypeConfiguration : IEntityTypeConfiguration<RoomType>
+    {
+        public void Configure(EntityTypeBuilder<RoomType> builder)
+        {
+            builder.HasKey(rt => rt.Id);
+
+            builder.Property(rt => rt.Name)
+                .IsRequired()
+                .HasMaxLength(100);
+
+            builder.Property(rt => rt.Description)
+                .HasMaxLength(500);
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/Context/HotelUltraGroupContext.cs
+++ b/HotelApp.Infraestructure.Data/Context/HotelUltraGroupContext.cs
@@ -1,0 +1,35 @@
+﻿using HotelApp.Domain.Entities;
+using HotelApp.Infraestructure.Persistence.Configurations;
+using Microsoft.EntityFrameworkCore;
+
+namespace HotelApp.Infraestructure.Persistence.Context
+{
+    public class HotelUltraGroupContext : DbContext
+    {
+        public HotelUltraGroupContext(DbContextOptions<HotelUltraGroupContext> options) : base(options){}
+
+        public DbSet<Hotel> Hotels { get; set; }
+        public DbSet<Room> Rooms { get; set; }
+        public DbSet<Reservation> Reservations { get; set; }
+        public DbSet<ReservationDetailGuest> ReservationDetailGuests { get; set; }
+        public DbSet<ReservationDetailRoom> ReservationDetailRooms { get; set; }
+        public DbSet<Guest> Guests { get; set; }
+        public DbSet<RoomType> RoomTypes { get; set; }
+        public DbSet<DocumentType> DocumentTypes { get; set; }
+
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.ApplyConfiguration(new HotelConfiguration());
+            modelBuilder.ApplyConfiguration(new RoomConfiguration());
+            modelBuilder.ApplyConfiguration(new ReservationConfiguration());
+            modelBuilder.ApplyConfiguration(new ReservationDetailRoomConfiguration());
+            modelBuilder.ApplyConfiguration(new ReservationDetailGuestConfiguration());
+            modelBuilder.ApplyConfiguration(new GuestConfiguration());
+            modelBuilder.ApplyConfiguration(new RoomTypeConfiguration());
+            modelBuilder.ApplyConfiguration(new DocumentTypeConfiguration());
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/DependencyInjection.cs
+++ b/HotelApp.Infraestructure.Data/DependencyInjection.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HotelApp.Infraestructure.Persistence
+{
+    public class DependencyInjection
+    {
+        public static void RegisterServices(IServiceCollection services)
+        {
+            
+        }
+    }
+}

--- a/HotelApp.Infraestructure.Data/HotelApp.Infraestructure.Data.csproj
+++ b/HotelApp.Infraestructure.Data/HotelApp.Infraestructure.Data.csproj
@@ -1,9 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-</Project>

--- a/HotelApp.Infraestructure.Data/HotelApp.Infraestructure.Persistence.csproj
+++ b/HotelApp.Infraestructure.Data/HotelApp.Infraestructure.Persistence.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HotelApp.Application\HotelApp.Application.csproj" />
+    <ProjectReference Include="..\HotelApp.Domain\HotelApp.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Repositories\" />
+  </ItemGroup>
+
+</Project>

--- a/SolutionHotelUltraGroup.sln
+++ b/SolutionHotelUltraGroup.sln
@@ -13,15 +13,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Infraestructure", "Infraest
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{174CB491-EE7C-4867-81B9-572B0A6FF1F8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotelApp.API", "HotelApp.API\HotelApp.API.csproj", "{D78F333B-38A1-4BE0-A53F-E3495CE4C17A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotelApp.API", "HotelApp.API\HotelApp.API.csproj", "{D78F333B-38A1-4BE0-A53F-E3495CE4C17A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotelApp.Application", "HotelApp.Application\HotelApp.Application.csproj", "{25013DAF-BF42-484D-B7A9-CE80B78D8BDD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotelApp.Application", "HotelApp.Application\HotelApp.Application.csproj", "{25013DAF-BF42-484D-B7A9-CE80B78D8BDD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotelApp.Domain", "HotelApp.Domain\HotelApp.Domain.csproj", "{A2C88155-7BF9-435E-91C3-ECEC3E46B6CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotelApp.Domain", "HotelApp.Domain\HotelApp.Domain.csproj", "{A2C88155-7BF9-435E-91C3-ECEC3E46B6CC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotelApp.Infraestructure.Data", "HotelApp.Infraestructure.Data\HotelApp.Infraestructure.Data.csproj", "{66E5B73A-BA67-409C-B117-D4131967456E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotelApp.Infraestructure.Persistence", "HotelApp.Infraestructure.Data\HotelApp.Infraestructure.Persistence.csproj", "{66E5B73A-BA67-409C-B117-D4131967456E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHotelApp", "TestHotelApp\TestHotelApp.csproj", "{2D4D34E5-9E2B-4CBE-837D-939501C03CBD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestHotelApp", "TestHotelApp\TestHotelApp.csproj", "{2D4D34E5-9E2B-4CBE-837D-939501C03CBD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Se ha añadido una referencia al proyecto `HotelApp.Infraestructure.Persistence` en el archivo `HotelApp.API.csproj`. En `Program.cs`, se han importado los espacios de nombres necesarios y se ha configurado el servicio `DbContext` para utilizar SQL Server con la cadena de conexión `SqlConecctionHotelUltraGroupDB`. También se ha registrado el método `DependencyInjection.RegisterServices`.

En `appsettings.json`, se ha añadido una sección de `ConnectionStrings` con la cadena de conexión `SqlConecctionHotelUltraGroupDB`. En `HotelApp.Application.csproj`, se ha añadido una referencia al proyecto `HotelApp.Domain`.

El archivo `HotelApp.Infraestructure.Data.csproj` ha sido eliminado y reemplazado por `HotelApp.Infraestructure.Persistence.csproj`. En `SolutionHotelUltraGroup.sln`, se han actualizado las referencias a los proyectos y se ha renombrado `HotelApp.Infraestructure.Data` a `HotelApp.Infraestructure.Persistence`.

Se han añadido varias clases de entidades en `HotelApp.Domain.Entities` y la clase `DependencyInjection` en `HotelApp.Infraestructure.Persistence` para registrar servicios. En `HotelApp.Infraestructure.Persistence.csproj`, se han añadido referencias a los proyectos `HotelApp.Application` y `HotelApp.Domain`, así como paquetes de NuGet para Entity Framework.

Se han añadido configuraciones de entidades en `HotelApp.Infraestructure.Persistence.Configurations` y la clase `HotelUltraGroupContext` en `HotelApp.Infraestructure.Persistence.Context`, que define los `DbSet` para las entidades y aplica las configuraciones en el método `OnModelCreating`.